### PR TITLE
Release for v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.1.4](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.1.3...v0.1.4) - 2025-11-08
+## [v0.2.0](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.1.3...v0.2.0) - 2025-11-08
 - feat: add option to include schedule items without tags by @handlename in https://github.com/handlename/obsidian-plugin-task-reporter/pull/6
 
 ## [v0.1.3](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.1.2...v0.1.3) - 2025-10-25

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "task-reporter",
 	"name": "Task Reporter",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"minAppVersion": "1.0.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"author": "handlename",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "task-reporter",
 	"name": "Task Reporter",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"minAppVersion": "1.0.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"author": "handlename",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-task-reporter",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This pull request is for the next release as v0.1.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: add option to include schedule items without tags by @handlename in https://github.com/handlename/obsidian-plugin-task-reporter/pull/6


**Full Changelog**: https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.1.3...v0.1.4