### PR TITLE
feat: add option to remove anchors from report output

### DIFF
--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -7,6 +7,7 @@ export interface PluginSettings {
 	schedulePrefix: string;
 	includeScheduleItems: boolean;
 	includeSubHeadings: boolean;
+	removeAnchors: boolean;
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -18,4 +19,5 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 	schedulePrefix: '🗓️',
 	includeScheduleItems: false,
 	includeSubHeadings: false,
+	removeAnchors: true,
 };

--- a/src/services/task-formatter.ts
+++ b/src/services/task-formatter.ts
@@ -4,6 +4,7 @@ import {
 	applyStrikethrough,
 	convertTag,
 	formatGitHubUrl,
+	removeAnchors,
 	removeInternalLinks,
 } from '../utils/text-formatter';
 
@@ -57,6 +58,11 @@ export function formatTaskContent(content: string, settings: PluginSettings): st
 
 	// FR-005: 内部リンク除去
 	result = removeInternalLinks(result);
+
+	// アンカー除去（設定で有効な場合）
+	if (settings.removeAnchors) {
+		result = removeAnchors(result);
+	}
 
 	// FR-006: GitHub URL整形
 	result = formatGitHubUrl(result);

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -105,5 +105,16 @@ export class TaskReporterSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				})
 			);
+
+		// アンカーを除去
+		new Setting(containerEl)
+			.setName('アンカーを除去')
+			.setDesc('ブロックリンク用のアンカー (^block-id) をレポートから除去する')
+			.addToggle((toggle) =>
+				toggle.setValue(this.plugin.settings.removeAnchors).onChange(async (value) => {
+					this.plugin.settings.removeAnchors = value;
+					await this.plugin.saveSettings();
+				})
+			);
 	}
 }

--- a/src/utils/text-formatter.ts
+++ b/src/utils/text-formatter.ts
@@ -33,6 +33,25 @@ export function removeInternalLinks(text: string): string {
 }
 
 /**
+ * アンカー（ブロックリンク）を除去する
+ * Obsidianのブロックリンク形式 ^block-id を除去
+ * @param text テキスト
+ * @returns アンカー除去後のテキスト
+ */
+export function removeAnchors(text: string): string {
+	// ブロックIDアンカー: ^block-id 形式を除去
+	// スペースの後に続くアンカー、またはリンク内のアンカー参照を対象
+	// 累乗表記(5^2など)を誤って除去しないよう、^の前にスペースか#が必要
+	return text.replace(/\s+\^[\w-]+|#\^[\w-]+/g, (match) => {
+		// #で始まる場合は#を残す
+		if (match.startsWith('#')) {
+			return '#';
+		}
+		return '';
+	});
+}
+
+/**
  * GitHub URLを整形する (FR-006)
  * Issue/PR URLを [repo#number](url) 形式に変換
  * ただし、既にMarkdownリンク内にあるURLは変換しない

--- a/tests/services/task-formatter.test.ts
+++ b/tests/services/task-formatter.test.ts
@@ -15,6 +15,7 @@ describe("task-formatter", () => {
 		schedulePrefix: "🗓️",
 		includeScheduleItems: false,
 		includeSubHeadings: false,
+		removeAnchors: true,
 	};
 
 	const createTask = (
@@ -72,6 +73,19 @@ describe("task-formatter", () => {
 			const content = "Plain task content";
 			const result = formatTaskContent(content, defaultSettings);
 			expect(result).toBe("Plain task content");
+		});
+
+		it("should remove anchors when removeAnchors is true", () => {
+			const content = "Task content ^block-id";
+			const result = formatTaskContent(content, defaultSettings);
+			expect(result).toBe("Task content");
+		});
+
+		it("should preserve anchors when removeAnchors is false", () => {
+			const content = "Task content ^block-id";
+			const settings = { ...defaultSettings, removeAnchors: false };
+			const result = formatTaskContent(content, settings);
+			expect(result).toBe("Task content ^block-id");
 		});
 	});
 

--- a/tests/utils/text-formatter.test.ts
+++ b/tests/utils/text-formatter.test.ts
@@ -2,6 +2,7 @@ import {
 	applyStrikethrough,
 	convertTag,
 	formatGitHubUrl,
+	removeAnchors,
 	removeInternalLinks,
 } from "../../src/utils/text-formatter";
 
@@ -113,6 +114,52 @@ describe("text-formatter", () => {
 			expect(removeInternalLinks(text)).toBe(
 				"Internal link, external [link](https://example.com), wiki, alias",
 			);
+		});
+	});
+
+	describe("removeAnchors", () => {
+		it("should remove block anchor at end of line", () => {
+			const text = "Task content ^block-id";
+			expect(removeAnchors(text)).toBe("Task content");
+		});
+
+		it("should remove anchor with only alphanumeric characters", () => {
+			const text = "Task content ^abc123";
+			expect(removeAnchors(text)).toBe("Task content");
+		});
+
+		it("should remove anchor with hyphens", () => {
+			const text = "Task content ^my-block-id";
+			expect(removeAnchors(text)).toBe("Task content");
+		});
+
+		it("should remove anchor with underscores", () => {
+			const text = "Task content ^my_block_id";
+			expect(removeAnchors(text)).toBe("Task content");
+		});
+
+		it("should remove multiple anchors", () => {
+			const text = "First ^anchor1 and second ^anchor2";
+			expect(removeAnchors(text)).toBe("First and second");
+		});
+
+		it("should not remove caret without valid block id", () => {
+			const text = "5^2 equals 25";
+			expect(removeAnchors(text)).toBe("5^2 equals 25");
+		});
+
+		it("should handle text without anchors", () => {
+			const text = "Plain text without anchors";
+			expect(removeAnchors(text)).toBe("Plain text without anchors");
+		});
+
+		it("should handle empty string", () => {
+			expect(removeAnchors("")).toBe("");
+		});
+
+		it("should preserve WikiLink with anchor", () => {
+			const text = "See [[Note#^block-id]] for details";
+			expect(removeAnchors(text)).toBe("See [[Note#]] for details");
 		});
 	});
 


### PR DESCRIPTION
## 概要
レポート出力結果からアンカー（`^block-id`形式のブロックリンク）を取り除くオプションを追加。

## 変更内容
- `PluginSettings`に`removeAnchors`オプションを追加（デフォルト: true）
- `removeAnchors()`関数を`text-formatter.ts`に実装
- `formatTaskContent()`で設定に応じてアンカー除去を実行
- 設定UIに「アンカーを除去」トグルを追加
- ユニットテストを追加（11ケース）

<img width="1086" height="771" alt="image" src="https://github.com/user-attachments/assets/eac3b477-9a1a-4df4-a284-51f7c3ab792f" />

## 影響範囲
- `src/models/settings.ts` - 設定インターフェース
- `src/utils/text-formatter.ts` - テキスト整形ユーティリティ
- `src/services/task-formatter.ts` - タスクフォーマッター
- `src/ui/settings-tab.ts` - 設定UI

## テスト
- [x] 関連テストが通過済み（143テスト全て通過）
- [x] 新規テストを追加

## 備考
累乗表記（`5^2`など）を誤って除去しないよう正規表現を調整済み。