### PR TITLE
Release for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.3.1](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.3.0...v0.3.1) - 2026-01-17
+## [v0.4.0](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.3.0...v0.4.0) - 2026-01-17
 - feat: add option to remove anchors from report output by @handlename in https://github.com/handlename/obsidian-plugin-task-reporter/pull/13
 
 ## [v0.3.0](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.2.1...v0.3.0) - 2025-12-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.3.1](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.3.0...v0.3.1) - 2026-01-17
+- feat: add option to remove anchors from report output by @handlename in https://github.com/handlename/obsidian-plugin-task-reporter/pull/13
+
 ## [v0.3.0](https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.2.1...v0.3.0) - 2025-12-28
 - feat: 対象見出し配下の子見出し内タスクも含める設定を追加 by @handlename in https://github.com/handlename/obsidian-plugin-task-reporter/pull/10
 - chore: update actions by @handlename in https://github.com/handlename/obsidian-plugin-task-reporter/pull/12

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "task-reporter",
 	"name": "Task Reporter",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"minAppVersion": "1.0.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"author": "handlename",

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "task-reporter",
 	"name": "Task Reporter",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"minAppVersion": "1.0.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"author": "handlename",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "task-reporter",
 	"name": "Task Reporter",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"minAppVersion": "1.0.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"author": "handlename",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "task-reporter",
 	"name": "Task Reporter",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"minAppVersion": "1.0.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"author": "handlename",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-task-reporter",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"main": "main.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-task-reporter",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Format task lists from Obsidian notes and copy to clipboard for daily reports",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This pull request is for the next release as v0.3.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: add option to remove anchors from report output by @handlename in https://github.com/handlename/obsidian-plugin-task-reporter/pull/13


**Full Changelog**: https://github.com/handlename/obsidian-plugin-task-reporter/compare/v0.3.0...tagpr-from-v0.3.0